### PR TITLE
Don’t cache dist-newstyle on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,12 +39,11 @@ jobs:
         ghc-version: ${{ matrix.ghc }}
 
     - uses: actions/cache@v4
-      name: Cache cabal stuff
+      name: Cache cabal store
       with:
-        path: |
-          ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
-          dist-newstyle
-        key: ${{ runner.os }}-${{ matrix.ghc }}
+        path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
+        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ github.sha }}
+        restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
 
     - name: Cabal version
       run: |


### PR DESCRIPTION
It's counterproductive: `dist-newstyle` may contain old object files which will not get rebuilt by the ghc if e.g. some flags change. While that may be an issue with ghc, it's best to build current project from scratch to avoid any nasty surprises.